### PR TITLE
feat: Add summary section above results table

### DIFF
--- a/jules-scratch/verification/verify_summary_section.py
+++ b/jules-scratch/verification/verify_summary_section.py
@@ -1,0 +1,35 @@
+import asyncio
+from playwright.async_api import async_playwright, expect
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page()
+
+        try:
+            await page.goto("http://127.0.0.1:5000")
+
+            # Fill in the search form
+            await page.fill("#first-name", "Albert")
+            await page.fill("#last-name", "Einstein")
+
+            # Click the search button
+            await page.click("#search-btn")
+
+            # Wait for the results section to be visible
+            results_section = page.locator("#results-section")
+            await expect(results_section).to_be_visible(timeout=60000)
+
+            # Wait for the summary section to be populated
+            summary_total_pubs = page.locator("#summary-total-pubs")
+            await expect(summary_total_pubs).not_to_have_text("0", timeout=10000)
+
+            # Take a screenshot of the summary section
+            summary_section = page.locator("#results-summary-section")
+            await summary_section.screenshot(path="jules-scratch/verification/verification.png")
+
+        finally:
+            await browser.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/static/script.js
+++ b/static/script.js
@@ -217,6 +217,19 @@ function displayResults(data) {
     if (data.researcher.orcid_id) infoParts.push(`ORCID ID: ${data.researcher.orcid_id}`);
     document.getElementById('researcher-info').textContent = infoParts.join(' • ');
 
+    // Populate new summary cards
+    const pubs = data.publications || [];
+    const totalPubs = pubs.length;
+    const avgCoverage = data.summary?.coverage_report?.average_coverage || 0;
+    const fullyCovered = pubs.filter(p => p.coverage_count === 4).length;
+    const gaps = totalPubs - fullyCovered;
+
+    document.getElementById('summary-total-pubs').textContent = totalPubs;
+    document.getElementById('summary-avg-coverage').textContent = `${Math.round(avgCoverage * 100)}%`;
+    document.getElementById('summary-fully-covered').textContent = fullyCovered;
+    document.getElementById('summary-gaps').textContent = gaps;
+
+    // Populate old summary line (can be removed later if redundant)
     document.getElementById('total-publications').textContent = data.summary.total_publications;
     document.getElementById('sources-used').textContent = data.summary.sources_used.join(', ');
     document.getElementById('average-coverage').textContent = `${Math.round((data.summary.coverage_report?.average_coverage || 0) * 100)}%`;

--- a/static/styles.css
+++ b/static/styles.css
@@ -230,3 +230,21 @@ body {
 @media (min-width: 640px) {
     .profile-modal .split { grid-template-columns: 1fr auto; }
 }
+
+/* --- Summary Cards --- */
+.summary-card {
+    transition: all 0.2s ease-in-out;
+}
+
+.summary-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 8px 20px rgba(0,0,0,0.07);
+}
+
+.summary-card .summary-icon {
+    transition: transform 0.3s ease;
+}
+
+.summary-card:hover .summary-icon {
+    transform: rotate(-10deg) scale(1.1);
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -262,6 +262,50 @@
                 </div>
             </div>
 
+            <!-- Results Summary Section -->
+            <div id="results-summary-section" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
+                <!-- Total Publications -->
+                <div class="summary-card bg-white rounded-xl shadow-light p-5 flex items-center">
+                    <div class="summary-icon mr-5 rounded-full w-12 h-12 flex items-center justify-center bg-gray-800">
+                        <i class="fas fa-book-open text-white text-xl"></i>
+                    </div>
+                    <div>
+                        <div class="text-gray-500 text-sm font-medium">Total Publications</div>
+                        <div id="summary-total-pubs" class="text-2xl font-bold text-gray-900">0</div>
+                    </div>
+                </div>
+                <!-- Average Coverage -->
+                <div class="summary-card bg-white rounded-xl shadow-light p-5 flex items-center">
+                    <div class="summary-icon mr-5 rounded-full w-12 h-12 flex items-center justify-center bg-blue-500">
+                        <i class="fas fa-shield-alt text-white text-xl"></i>
+                    </div>
+                    <div>
+                        <div class="text-gray-500 text-sm font-medium">Avg. Coverage</div>
+                        <div id="summary-avg-coverage" class="text-2xl font-bold text-gray-900">0%</div>
+                    </div>
+                </div>
+                <!-- Fully Covered -->
+                <div class="summary-card bg-white rounded-xl shadow-light p-5 flex items-center">
+                    <div class="summary-icon mr-5 rounded-full w-12 h-12 flex items-center justify-center bg-green-500">
+                        <i class="fas fa-check-circle text-white text-xl"></i>
+                    </div>
+                    <div>
+                        <div class="text-gray-500 text-sm font-medium">Fully Covered</div>
+                        <div id="summary-fully-covered" class="text-2xl font-bold text-gray-900">0</div>
+                    </div>
+                </div>
+                <!-- Missing from at least one -->
+                <div class="summary-card bg-white rounded-xl shadow-light p-5 flex items-center">
+                    <div class="summary-icon mr-5 rounded-full w-12 h-12 flex items-center justify-center bg-orange-500">
+                        <i class="fas fa-exclamation-triangle text-white text-xl"></i>
+                    </div>
+                    <div>
+                        <div class="text-gray-500 text-sm font-medium">Coverage Gaps</div>
+                        <div id="summary-gaps" class="text-2xl font-bold text-gray-900">0</div>
+                    </div>
+                </div>
+            </div>
+
             <!-- Simplified Filters -->
             <div class="bg-white rounded-lg p-4 mb-6 shadow-light">
                 <div class="flex flex-wrap gap-4 items-center justify-between">


### PR DESCRIPTION
This commit introduces a new summary section that is displayed above the publication results table. This section provides at-a-glance metrics about the search results, including:

- Total number of publications found
- Average coverage across the configured databases
- Number of publications that are fully covered (present in all databases)
- Number of publications with coverage gaps

The summary section is implemented with a responsive grid layout and includes icons and styling for better visual appeal. The cards also have a hover effect for interactivity.