### PR TITLE
Fix: Resolve 500 error in report generation page

### DIFF
--- a/app.py
+++ b/app.py
@@ -671,6 +671,22 @@ def view_report(report_id):
         with open(report_path, 'r', encoding='utf-8') as f:
             report_data = json.load(f)
 
+        # Sort publications in the backend to handle missing years gracefully
+        if 'publications' in report_data and isinstance(report_data['publications'], list):
+            report_data['publications'].sort(key=lambda p: p.get('year') or 0, reverse=True)
+
+        # Format timestamp in the backend for robustness
+        researcher_data = report_data.get('researcher', {})
+        timestamp_str = researcher_data.get('search_timestamp', '')
+        formatted_timestamp = ''
+        if timestamp_str:
+            try:
+                dt_object = datetime.fromisoformat(timestamp_str)
+                formatted_timestamp = dt_object.strftime('%Y-%m-%d %H:%M:%S')
+            except (ValueError, TypeError):
+                formatted_timestamp = str(timestamp_str).split('.')[0].replace('T', ' ')
+        researcher_data['formatted_timestamp'] = formatted_timestamp
+
         # Pass the full data, and also data as a JSON string for JS embedding
         return render_template('report.html', report=report_data, report_json=json.dumps(report_data))
 

--- a/templates/report.html
+++ b/templates/report.html
@@ -48,7 +48,7 @@
                          <i class="fas fa-book-open text-gray-700 mr-2"></i>
                         <span class="font-light text-xl">Pub<span class="font-semibold">Crawler</span></span>
                     </div>
-                     <p class="text-xs text-gray-500 mt-2">Report generated on {{ report.researcher.search_timestamp | tojson | fromjson | replace('T', ' ') | slice(0, 19) }}</p>
+                     <p class="text-xs text-gray-500 mt-2">Report generated on {{ report.researcher.formatted_timestamp }}</p>
                 </div>
             </div>
         </header>
@@ -59,11 +59,11 @@
                 <h2 class="text-2xl font-semibold text-gray-700 mb-4">Summary</h2>
                 <div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
                     <div class="bg-gray-50 p-4 rounded-lg">
-                        <p class="text-3xl font-bold text-gray-800">{{ report.summary.unique_publications }}</p>
+                        <p class="text-3xl font-bold text-gray-800">{{ report.summary.unique_publications or 0 }}</p>
                         <p class="text-sm text-gray-600">Unique Publications</p>
                     </div>
                     <div class="bg-gray-50 p-4 rounded-lg">
-                        <p class="text-3xl font-bold text-gray-800">{{ report.summary.coverage_report.summary.total_citations }}</p>
+                        <p class="text-3xl font-bold text-gray-800">{{ report.summary.coverage_report.total_citations or 0 }}</p>
                         <p class="text-sm text-gray-600">Total Citations</p>
                     </div>
                     <div class="bg-gray-50 p-4 rounded-lg">
@@ -96,7 +96,7 @@
             <section class="page-break">
                 <h2 class="text-2xl font-semibold text-gray-700 mb-4">Publication List</h2>
                 <div class="space-y-4">
-                    {% for pub in report.publications | sort(attribute='year', reverse=True) %}
+                    {% for pub in report.publications %}
                     <div class="publication-item border-t pt-4">
                         <p class="font-semibold text-gray-800">{{ pub.title }}</p>
                         <p class="text-sm text-gray-600 mt-1">{{ pub.authors | join(', ') }}</p>


### PR DESCRIPTION
This commit fixes a 500 server error that occurred when trying to view a generated sharable report. The error was caused by two main issues in the template rendering logic:

1.  A `TypeError` would occur when the Jinja2 `sort` filter attempted to sort publications by year, but some publications were missing a year value (i.e., `None`).
2.  An incorrect data path was used to access summary statistics (`total_citations`), which could lead to an error if the data structure was not as expected.
3.  The timestamp formatting in the template was overly complex and could be fragile.

The following changes have been made to resolve these issues:

-   **In `app.py`**: The `view_report` route now handles data pre-processing on the backend before rendering the template.
    -   It sorts the list of publications using Python's `sort`, which gracefully handles `None` values.
    -   It formats the ISO timestamp into a simple, readable string.
-   **In `templates/report.html`**:
    -   The template now iterates over the pre-sorted list of publications, removing the need for the `sort` filter.
    -   The paths to access summary statistics have been corrected.
    -   The template now uses the pre-formatted timestamp string from the backend.

These changes make the report generation feature more robust and resilient to missing or variable data.